### PR TITLE
feat: separate Wallet entity from User and update schema

### DIFF
--- a/src/main/java/org/example/cointoss/entities/User.java
+++ b/src/main/java/org/example/cointoss/entities/User.java
@@ -32,9 +32,9 @@ public class User {
     @Column(name = "password", nullable = false)
     private String password;
 
-    @ColumnDefault("0.00")
-    @Column(name = "usdt_balance", precision = 10, scale = 2)
-    private BigDecimal usdtBalance;
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = false)
+    private Wallet wallet;
 
     @ColumnDefault("CURRENT_TIMESTAMP")
     @Column(name = "created_at")

--- a/src/main/java/org/example/cointoss/entities/Wallet.java
+++ b/src/main/java/org/example/cointoss/entities/Wallet.java
@@ -1,0 +1,40 @@
+package org.example.cointoss.entities;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "wallets", schema = "cointoss")
+public class Wallet {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @NotNull
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @ColumnDefault("100.00")
+    @Column(name = "balance", precision = 10, scale = 2, nullable = false)
+    private BigDecimal balance;
+
+    @Column(name = "currency", length = 10, nullable = false)
+    private String currency = "USDT";
+
+    @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+}

--- a/src/main/resources/db/migration/V2__Wallet_Model.sql
+++ b/src/main/resources/db/migration/V2__Wallet_Model.sql
@@ -1,0 +1,15 @@
+-- Migration to support Wallet model and remove balance from users
+
+-- 1. Remove usdt_balance from users table
+ALTER TABLE users DROP COLUMN usdt_balance;
+
+-- 2. Create wallets table
+CREATE TABLE wallets (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    user_id BIGINT NOT NULL UNIQUE,
+    balance DECIMAL(10, 2) NOT NULL DEFAULT 100.00,
+    currency VARCHAR(10) NOT NULL DEFAULT 'USDT',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);


### PR DESCRIPTION
This pull request introduces a new `Wallet` model to better encapsulate user balances, moving the balance information out of the `User` entity and into its own table. The migration script updates the database schema accordingly, ensuring a clear separation of concerns between user information and wallet/balance management.

**Database schema and model changes:**

* Added a new `Wallet` entity class (`Wallet.java`) with a one-to-one relationship to `User`, including fields for `balance`, `currency`, and timestamps.
* Updated the `User` entity to remove the `usdtBalance` field and replace it with a one-to-one association to the new `Wallet` entity.

**Database migration:**

* Added migration script `V2__Wallet_Model.sql` to:
  * Remove the `usdt_balance` column from the `users` table.
  * Create a new `wallets` table with appropriate fields and constraints, including a default balance and currency.- Created Wallet entity with one-to-one relation to User
- Removed balance from User and added to Wallet
- Updated